### PR TITLE
Cross-Env da porta 8081 foi liberada para testes nos ambientes locais

### DIFF
--- a/src/main/java/laboratorioPedag/UMC_TCC_BACKEND/UmcTccBackendAccess.java
+++ b/src/main/java/laboratorioPedag/UMC_TCC_BACKEND/UmcTccBackendAccess.java
@@ -1,0 +1,25 @@
+package laboratorioPedag.UMC_TCC_BACKEND;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class UmcTccBackendAccess {
+
+    @Bean
+    public FilterRegistrationBean corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration().applyPermitDefaultValues();
+        config.addAllowedMethod(HttpMethod.PUT);
+        config.addAllowedMethod(HttpMethod.DELETE);
+        source.registerCorsConfiguration("/**", config);
+        FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+        bean.setOrder(0);
+        return bean;
+    }
+}

--- a/src/main/java/laboratorioPedag/UMC_TCC_BACKEND/agenda/rest/AgendaController.java
+++ b/src/main/java/laboratorioPedag/UMC_TCC_BACKEND/agenda/rest/AgendaController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.*;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:8081")
 @RequestMapping("/api/v1/agenda")
 public class AgendaController {
 

--- a/src/main/java/laboratorioPedag/UMC_TCC_BACKEND/usuario/rest/UsuarioController.java
+++ b/src/main/java/laboratorioPedag/UMC_TCC_BACKEND/usuario/rest/UsuarioController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:8081")
 @RequestMapping("/api/v1/usuario")
 public class UsuarioController {
 


### PR DESCRIPTION
UmcTccBackendAccess foi criada para configuração global de cross-env.
@Cross adicionado aos controllers para acesso da porta 8081.
TODO: modificar para a porta disponibilizada pela faculdade nos servidores internos em caso de deploy.
